### PR TITLE
Add Cython as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
   long_description_content_type='text/markdown',
   license="MIT License",
   test_suite='tests.test_all',
-  install_requires=[],
+  install_requires=['Cython'],
   ext_modules=ext_modules,
   classifiers=[
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
This fixes the bug where if pybloomfiltermmap3 is installed without Cython or not in order, it will fail.