### PR TITLE
Fix copy_template method for python3 use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if sys.version_info[0] < 3:
 
 setup(
   name='pybloomfiltermmap3',
-  version="0.4.18",
+  version="0.4.19",
   author="Michael Axiak, Rob Stacey, Prashant Sinha",
   author_email="prashant@noop.pw",
   url="https://github.com/prashnts/pybloomfiltermmap3",

--- a/src/pybloomfilter.pyx
+++ b/src/pybloomfilter.pyx
@@ -225,7 +225,7 @@ cdef class BloomFilter:
         cdef BloomFilter copy = BloomFilter(0, 0, NoConstruct)
         if os.path.exists(filename):
             os.unlink(filename)
-        copy._bf = cbloomfilter.bloomfilter_Copy_Template(self._bf, filename, perm)
+        copy._bf = cbloomfilter.bloomfilter_Copy_Template(self._bf, filename.encode(), perm)
         return copy
 
     def copy(self, filename):

--- a/tests/simpletest.py
+++ b/tests/simpletest.py
@@ -219,6 +219,14 @@ class SimpleTestCase(unittest.TestCase):
         self.assertEqual(pybloomfilter.BloomFilter.ReadFile,
                           bf.ReadFile)
 
+    def test_copy_template(self):
+        self._populate_filter(self.bf)
+        with tempfile.NamedTemporaryFile() as _file:
+            bf2 = self.bf.copy_template(_file.name)
+            self.assertPropertiesPreserved(self.bf, bf2)
+            bf2.union(self.bf)  # Asserts copied bloom filter is comparable
+            self._check_filter_contents(bf2)
+
 
 def suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
The `copy_template` method could not be used because the `filename` variable passed to the `copy_template` method was a string, not bytes as expected. This fixes that. I ran the tests, succesfully. I dont think this one line change merits a new test, but if you do let me know and I'll add one