### PR TITLE
Add bit_array property to inspect Bloom filter bit data

### DIFF
--- a/src/cbloomfilter.pxd
+++ b/src/cbloomfilter.pxd
@@ -6,6 +6,8 @@ cdef extern from "mmapbitarray.h":
      ctypedef struct MBArray:
          long bits
          long size
+         long bytes
+         long preamblebytes
          char * filename
          int fd
 

--- a/src/pybloomfilter.pyx
+++ b/src/pybloomfilter.pyx
@@ -180,6 +180,14 @@ cdef class BloomFilter:
         self._bf = NULL
 
     @property
+    def bit_array(self):
+        self._assert_open()
+        start_pos = self._bf.array.preamblebytes
+        end_pos = start_pos + self._bf.array.bytes
+        arr = (<char *>cbloomfilter.mbarray_CharData(self._bf.array))[start_pos:end_pos]
+        return int.from_bytes(arr, byteorder="big", signed=False)
+
+    @property
     def hash_seeds(self):
         self._assert_open()
         seeds = array.array('I')

--- a/tests/simpletest.py
+++ b/tests/simpletest.py
@@ -287,8 +287,7 @@ class SimpleTestCase(unittest.TestCase):
                                         self.tempfile.name)
         bf1.add(test_data)
         bf1_seeds = bf1.hash_seeds.tolist()
-        bf1_base64 = bf1.to_base64()
-        bf1.close()
+        bf1_ba = bf1.bit_array
 
         bf2 = pybloomfilter.BloomFilter(self.FILTER_SIZE,
                                         self.FILTER_ERROR_RATE,
@@ -296,11 +295,12 @@ class SimpleTestCase(unittest.TestCase):
                                         hash_seeds=bf1_seeds)
         bf2.add(test_data)
         bf2_seeds = bf2.hash_seeds.tolist()
-        bf2_base64 = bf2.to_base64()
-        bf2.close()
+        bf2_ba = bf2.bit_array
 
         self.assertEqual(bf1_seeds, bf2_seeds)
-        self.assertEqual(bf1_base64, bf2_base64)
+
+        # Expecting same hashing sequence
+        self.assertEqual(bf1_ba, bf2_ba)
 
     def test_bit_array(self):
         bf = pybloomfilter.BloomFilter(1000, 0.01, self.tempfile.name)
@@ -349,7 +349,6 @@ class SimpleTestCase(unittest.TestCase):
 
         bf1_hs = bf1.hash_seeds
         bf1_ba = bf1.bit_array
-        bf1.close()
 
         # In-memory
         bf2 = pybloomfilter.BloomFilter(capacity, 0.01, hash_seeds=bf1_hs)

--- a/tests/simpletest.py
+++ b/tests/simpletest.py
@@ -302,6 +302,64 @@ class SimpleTestCase(unittest.TestCase):
         self.assertEqual(bf1_seeds, bf2_seeds)
         self.assertEqual(bf1_base64, bf2_base64)
 
+    def test_bit_array(self):
+        bf = pybloomfilter.BloomFilter(1000, 0.01, self.tempfile.name)
+        bf.add("apple")
+
+        # Count the number of 1s
+        total_ones = 0
+        bit_array_str = bin(bf.bit_array)
+        for c in bit_array_str:
+            if c == "1":
+                total_ones += 1
+
+        # For the first item addition, BF should contain
+        # the same amount of 1s as the number of hashes
+        # performed
+        assert total_ones == bf.num_hashes
+
+        for i in range(1000):
+            bf.add(randint(0, 1000))
+
+        bf.add("apple")
+        ba_1 = bf.bit_array
+
+        bf.add("apple")
+        ba_2 = bf.bit_array
+
+        # Should be the same
+        assert ba_1 ^ ba_2 == 0
+
+        bf.add("pear")
+        bf.add("mango")
+        ba_3 = bf.bit_array
+
+        # Should not be the same
+        assert ba_1 ^ ba_3 != 0
+
+    def test_bit_array_same_hashes(self):
+        capacity = 100 * 100
+        items = []
+        for i in range(capacity):
+            items.append(randint(0, 1000))
+        
+        # File-backed
+        bf1 = pybloomfilter.BloomFilter(capacity, 0.01, self.tempfile.name)
+        bf1.update(items)
+
+        bf1_hs = bf1.hash_seeds
+        bf1_ba = bf1.bit_array
+        bf1.close()
+
+        # In-memory
+        bf2 = pybloomfilter.BloomFilter(capacity, 0.01, hash_seeds=bf1_hs)
+        bf2.update(items)
+
+        bf2_ba = bf2.bit_array
+
+        # Should be identical as data was hashed into the same locations
+        assert bf1_ba ^ bf2_ba == 0
+
 
 def suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
The `bit_array` property returns an integer that represents the Bloom filter data in its purest form.
Added unit tests also illustrating some of the use possibilities.

Needless to say, you won't actually be able to make assumptions about how things are hashed just from the bit array. If you create a Bloom filter from the same list of hash seeds, you will be able to ensure that the two have the same bit data. But if you want to make sure it was hashed correctly (possible test use case?), you'd need to manually perform hashing outside of the library, flip the bits in some bit array, and then compare it to the outcome of `bf.add(something)`. All in all this feature has limited uses, but I believe it may be good, esp. as @AaronRanAn mentioned, for educational purposes and debugging.

Ref. https://github.com/prashnts/pybloomfiltermmap3/issues/19