### PR TITLE
Streamline "r", "rw" and "rw+" (create) operations

### DIFF
--- a/src/pybloomfilter.pyx
+++ b/src/pybloomfilter.pyx
@@ -9,16 +9,16 @@ __VERSION__ = VERSION
 cimport cbloomfilter
 cimport cpython
 
-import random
-import os
-import math
-import errno as eno
 import array
-import zlib
+from base64 import b64encode, b64decode
+import errno as eno
+import math
+import os
+import random
 import shutil
 import sys
-import base64
 import warnings
+import zlib
 
 
 cdef extern int errno
@@ -483,7 +483,7 @@ cdef class BloomFilter:
             raise ValueError("Write operation on read-only file")
 
     def _assert_comparable(self, BloomFilter other):
-        error = ValueError("The two %s objects are not the same type (hint, "
+        error = ValueError("The two %s objects are not the same type (hint: "
                            "use copy_template)" % self.__class__.__name__)
         if self._bf.array.bits != other._bf.array.bits:
             raise error
@@ -500,14 +500,15 @@ cdef class BloomFilter:
         :rtype: base64 encoded string representing filter
         """
         self._assert_open()
-        bfile = open(self.filename, 'rb')
+        bfile = open(self.filename, "rb")
         fl_content = bfile.read()
-        result = base64.b64encode(zlib.compress(base64.b64encode(zlib.compress(fl_content, 9))))
+        result = b64encode(zlib.compress(b64encode(zlib.compress(
+            fl_content, 9))))
         bfile.close()
         return result
 
     @classmethod
-    def from_base64(cls, filename, string, mode="rw+", perm=0755):
+    def from_base64(cls, filename, string, mode="rw", perm=0755):
         """Unpacks the supplied base64 string (as returned by :meth:`BloomFilter.to_base64`)
         into the supplied filename and return a :class:`BloomFilter` object using that
         file.
@@ -517,9 +518,9 @@ cdef class BloomFilter:
         :param int perm: file access permission flags
         :rtype: :class:`BloomFilter`
         """
-        bfile_fp = os.open(filename, _construct_mode('w+'), perm)
-        os.write(bfile_fp, zlib.decompress(base64.b64decode(zlib.decompress(
-            base64.b64decode(string)))))
+        bfile_fp = os.open(filename, _construct_mode("w+"), perm)
+        os.write(bfile_fp, zlib.decompress(b64decode(zlib.decompress(
+            b64decode(string)))))
         os.close(bfile_fp)
         return cls.open(filename, mode)
 

--- a/tests/simpletest.py
+++ b/tests/simpletest.py
@@ -250,15 +250,6 @@ class SimpleTestCase(unittest.TestCase):
         bf = pybloomfilter.BloomFilter(100, 0.01)
         self.assertRaises(NotImplementedError, bf.to_base64)
 
-    def test_ReadFile_is_public(self):
-        self.assertEqual(
-            isinstance(pybloomfilter.BloomFilter.ReadFile, object), True)
-        bf = pybloomfilter.BloomFilter(100, 0.01)
-        bf2 = pybloomfilter.BloomFilter(100, 0.01)
-        self.assertEqual(bf.ReadFile, bf2.ReadFile)
-        self.assertEqual(pybloomfilter.BloomFilter.ReadFile,
-                          bf.ReadFile)
-
     def test_copy_template(self):
         self._populate_filter(self.bf)
         with tempfile.NamedTemporaryFile() as _file:

--- a/tests/simpletest.py
+++ b/tests/simpletest.py
@@ -135,12 +135,12 @@ class SimpleTestCase(unittest.TestCase):
         self._check_filter_contents(bf1)
         self.assertEqual(bf1.read_only, False)
 
-        bf2 = pybloomfilter.BloomFilter.open(self.bf.name.decode(), mode="rw")
+        bf2 = pybloomfilter.BloomFilter.open(self.bf.filename, mode="rw")
         self._check_filter_contents(bf2)
         self.assertEqual(bf2.read_only, False)
 
         # Read only
-        bfro = pybloomfilter.BloomFilter.open(self.bf.name.decode(), mode="r")
+        bfro = pybloomfilter.BloomFilter.open(self.bf.filename, mode="r")
         self._check_filter_contents(bfro)
         self.assertEqual(bfro.read_only, True)
 


### PR DESCRIPTION
Regression: removed "mode" parameter from `BloomFilter.from_base64()` introduced in 0.5.0 (https://github.com/prashnts/pybloomfiltermmap3/pull/13)

I had doubts about the existing flow in `pybloomfilter.pyx`, so hopefully these changes will clear things up a little:

* By creating a `BloomFilter` instance, we expect a new file to be created by default (or done in-memory). No `mode` argument should be supplied.
* By calling `BloomFilter.open()`, we expect a file to already be present for reading, thus allowing to specify the file read `mode` (either "r" (read-only) or "rw").
* By calling `BloomFilter.from_base64()` / `BloomFilter.copy()` / `BloomFilter.copy_template()`, we create a file implicitly and open it in "rw" mode.
