### PR TITLE
Cleanup alignment bytes after initializing BloomFilter

### DIFF
--- a/src/bloomfilter.c
+++ b/src/bloomfilter.c
@@ -17,6 +17,8 @@ BloomFilter *bloomfilter_Create_Malloc(size_t max_num_elem, double error_rate,
     if (!bf) {
         return NULL;
     }
+    /* Cleanup alignment artifacts */
+    memset(bf, 0, sizeof(BloomFilter));
 
     bf->max_num_elem = max_num_elem;
     bf->error_rate = error_rate;
@@ -49,6 +51,8 @@ BloomFilter *bloomfilter_Create_Mmap(size_t max_num_elem, double error_rate,
     if (!bf) {
         return NULL;
     }
+    /* Cleanup alignment artifacts */
+    memset(bf, 0, sizeof(BloomFilter));
 
     bf->max_num_elem = max_num_elem;
     bf->error_rate = error_rate;
@@ -127,6 +131,8 @@ BloomFilter * bloomfilter_Copy_Template(BloomFilter * src, char * filename, int 
     if (bf == NULL) {
         return NULL;
     }
+    /* Cleanup alignment artifacts */
+    memset(bf, 0, sizeof(BloomFilter));
 
     array = mbarray_Copy_Template(src->array, filename, perms);
     if (array == NULL) {


### PR DESCRIPTION
After the implementation of https://github.com/prashnts/pybloomfiltermmap3/pull/14, I realized that I wasn't able to fully replicate the mmap'd BloomFilter instance, as on different machines (or sometimes different Python processes) the `to_base64()` method would return different strings, diverging at a specific location.

I was able to find the issue with loads of help from @yonathan-adipradana.
Doing memset after initializing BloomFilter instance solved this issue by having relevant bytes set to 0 prior to populating the filter.

To replicate the issue on previous versions:
```
from pybloomfilter import BloomFilter
from zlib import compress, decompress
from base64 import b64encode, b64decode

b64_repr = "eJwFwUsOgjAUAMADuZCgKBsXhQeIWKRaEuquFihGPoYqDzm9M1U6LmUdU8UwUcNshM2IRssAwWfgSxjHjO6ssssn6bLsYTesqrtj0/dgYSuqzZ1cwISL1YrcH9V9PQ3cdN/JuRqn6nkRynUtd8rpmkldMt7Kb5EfF5d/IEl1GP/8LUuEYHN0HR5ihXL/1u65WKKZQkFsDykPfhQCpEAGGqexd4MX+vgkJ0/LCHIRNXpL0rk8SXH4A2pERcg="
hash_seeds = [3837895095, 3446164276, 218928576, 318812276, 2715048734, 4231234832, 2646234356, 1058991177, 1248068903, 1134013883, 3269341494, 3044656612, 3079736504]

t0 = BloomFilter.from_base64("/tmp/test_bloom0", b64_repr)

t1 = BloomFilter(t0.capacity, t0.error_rate, "/tmp/test_bloom1", hash_seeds=t0.hash_seeds.tolist())
t1.add("5f35c4edcdb5b970ac8939a3c7abb3347ed9c4e3e251cbc799bdaeba008ce7aa")
t1.add("f416d946d98166066611fb1a5e262c5f241d9bfdd8c885e062433b6f6b73799a")

assert t1.to_base64() == t0.to_base64() # raises AssertionError
```