### PR TITLE
Add readthedocs configuration and badges in readme

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,27 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements-dev.txt
+    - method: setuptools
+      path: .
+  system_packages: true
+

--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,7 @@ The goal of `pybloomfiltermmap3` is simple: to provide a fast, simple, scalable,
 [![PyPI](https://img.shields.io/pypi/v/pybloomfiltermmap3.svg)](https://pypi.python.org/pypi/pybloomfiltermmap3)
 [![PyPI](https://img.shields.io/pypi/dw/pybloomfiltermmap3.svg)](https://pypi.python.org/pypi/pybloomfiltermmap3)
 [![PyPI](https://img.shields.io/pypi/pyversions/pybloomfiltermmap3.svg)](https://pypi.python.org/pypi/pybloomfiltermmap3)
+[![Documentation Status](https://readthedocs.org/projects/pybloomfiltermmap3/badge/?version=latest)](https://pybloomfiltermmap3.readthedocs.io/en/latest/?badge=latest)
 
 
 ## Quickstart

--- a/README.markdown
+++ b/README.markdown
@@ -36,8 +36,7 @@ To create an in-memory filter, simply omit the file location:
 
 ## Docs
 
-Follow the *official* docs for `pybloomfiltermmap` at: http://axiak.github.io/pybloomfiltermmap/
-
+Current docs are available at [pybloomfiltermmap3.rtfd.io](https://pybloomfiltermmap3.readthedocs.io/en/latest).
 
 ## Install
 


### PR DESCRIPTION
This PR is to wrap up documentation site and badges.

Current version is at:
https://pybloomfiltermmap3.readthedocs.io/en/latest/