### PR TITLE
add special case for bytes()

### DIFF
--- a/src/pybloomfilter.pyx
+++ b/src/pybloomfilter.pyx
@@ -323,6 +323,10 @@ cdef class BloomFilter:
             item = item_.encode()
             key.shash = item
             key.nhash = len(item)
+        elif isinstance(item_, bytes):
+            item = item_
+            key.shash = item
+            key.nhash = len(item)
         else:
             item = item_
             key.shash = NULL
@@ -372,6 +376,10 @@ cdef class BloomFilter:
         cdef cbloomfilter.Key key
         if isinstance(item_, str):
             item = item_.encode()
+            key.shash = item
+            key.nhash = len(item)
+        elif isinstance(item_, bytes):
+            item = item_
             key.shash = item
             key.nhash = len(item)
         else:

--- a/tests/simpletest.py
+++ b/tests/simpletest.py
@@ -356,6 +356,22 @@ class SimpleTestCase(unittest.TestCase):
         # Should be identical as data was hashed into the same locations
         assert bf1_ba ^ bf2_ba == 0
 
+    def test_add_contains(self):
+        values = [
+            '',
+            'string',
+            b'',
+            b'bytes',
+            True,
+            False,
+            0,
+            10,
+        ]
+        for value in values:
+            bf = pybloomfilter.BloomFilter(1000, 0.1)
+            bf.add(value)
+            assert value in bf
+
 
 def suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
Hi,

I noticed in the code that there's a special case for `str()` but not for `bytes()` so I added it and made a simple test (it tests that special cases are added to both add and __contains__).

Let me know what you think.

babush